### PR TITLE
automatically forward content type

### DIFF
--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -23,7 +23,7 @@ npm run dev
 curl -X POST http://localhost:3000/proxy \
 -H "T-PROXY-URL: https://jsonplaceholder.typicode.com/posts" \
 -H "T-STORE: storeone" \
--H "foward-Content-Type: application/json" \
+-H "forward-Content-Type: application/json" \
 -H "Content-Type: application/json" \
 -d '{"title": "usher", "body": "labs", "userId": 10}'
 ```

--- a/packages/proxy/src/utils/constants.ts
+++ b/packages/proxy/src/utils/constants.ts
@@ -1,6 +1,24 @@
-export const T_HEADERS = {
-  T_PROXY_URL: "T-PROXY-URL",
-  T_REDACTED: "T-REDACTED",
-  T_STORE: "T-STORE",
-  T_PUBLISH: "T_PUBLISH",
+interface HeadersInterface {
+	[key: string]: string;
+}
+
+export const T_HEADERS: HeadersInterface = {
+	T_PROXY_URL: 'T-PROXY-URL',
+	T_REDACTED: 'T-REDACTED',
+	T_STORE: 'T-STORE',
+	T_PUBLISH: 'T-PUBLISH',
 };
+
+export const BLACKLISTED_HEADERS = [
+	...Object.values(T_HEADERS).map((h) => h.toLowerCase()),
+  // blacklist all the headers which could cause an error
+  // or one that has already been set by the prover
+	'host',
+	'user-agent',
+	'postman-token',
+	'accept-encoding',
+	'cache-control',
+	'content-length',
+  'accept',
+  'connection',
+];


### PR DESCRIPTION
This PR automatically forwards the content-type header, however if we pass in all headers, there are some headers that will cause the request to break. in my case i tried for postman and curl and passing in all headers caused the rust process to crash.  So i just forward the content type and use the prefix on headers we want to forward.